### PR TITLE
Add basic FastAPI RAG service

### DIFF
--- a/rag-fastapi/.env.template
+++ b/rag-fastapi/.env.template
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-key

--- a/rag-fastapi/app/loader.py
+++ b/rag-fastapi/app/loader.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+import chromadb
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "source.txt"
+
+
+def load_embeddings(persist_directory: str = "chromadb") -> chromadb.api.models.Collection.Collection:
+    """Load documents from source.txt, split them, and create embeddings."""
+    client = chromadb.PersistentClient(path=persist_directory)
+    embed_fn = OpenAIEmbeddingFunction(api_key=os.environ.get("OPENAI_API_KEY"))
+    collection = client.get_or_create_collection("docs", embedding_function=embed_fn)
+
+    if collection.count() == 0:
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            text = f.read()
+        chunks = [c.strip() for c in text.split("\n\n") if c.strip()]
+        ids = [str(i) for i in range(len(chunks))]
+        collection.add(documents=chunks, ids=ids)
+
+    return collection

--- a/rag-fastapi/app/main.py
+++ b/rag-fastapi/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+from .rag import query_rag
+
+app = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    query: str
+    history: List[str] = []
+
+
+class ChatResponse(BaseModel):
+    answer: str
+    sources: List[str]
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest):
+    result = query_rag(req.query, req.history)
+    return result

--- a/rag-fastapi/app/rag.py
+++ b/rag-fastapi/app/rag.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, List
+import os
+import openai
+
+from .loader import load_embeddings
+
+collection = load_embeddings()
+
+
+def query_rag(question: str, history: List[str] | None = None, k: int = 3) -> Dict[str, Any]:
+    """Search vectors and generate an answer using OpenAI."""
+    results = collection.query(query_texts=[question], n_results=k)
+    docs = results["documents"][0]
+    context = "\n\n".join(docs)
+
+    messages = [
+        {
+            "role": "system",
+            "content": "Answer the user's question based on the provided context.",
+        },
+        {
+            "role": "user",
+            "content": f"Context:\n{context}\n\nQuestion: {question}",
+        },
+    ]
+
+    response = openai.ChatCompletion.create(model="gpt-4o", messages=messages)
+    answer = response.choices[0].message.content.strip()
+    return {"answer": answer, "sources": docs}

--- a/rag-fastapi/data/source.txt
+++ b/rag-fastapi/data/source.txt
@@ -1,0 +1,1 @@
+Replace this text with your domain-specific documentation.

--- a/rag-fastapi/requirements.txt
+++ b/rag-fastapi/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+chromadb
+openai
+python-dotenv
+uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI skeleton under `rag-fastapi`
- implement loader, RAG functions, and API endpoint
- provide requirements, sample env file and placeholder data

## Testing
- `npm test` *(fails: `sfdx-lwc-jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68663aab12c883278c36c666e605cb03