### PR TITLE
Add basic chat UI components

### DIFF
--- a/force-app/main/default/lwc/chatLauncher/chatLauncher.css
+++ b/force-app/main/default/lwc/chatLauncher/chatLauncher.css
@@ -1,0 +1,6 @@
+.launcher {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 1000;
+}

--- a/force-app/main/default/lwc/chatLauncher/chatLauncher.html
+++ b/force-app/main/default/lwc/chatLauncher/chatLauncher.html
@@ -1,0 +1,8 @@
+<template>
+    <template if:false={open}>
+        <lightning-button-icon icon-name="utility:chat" variant="brand" alternative-text="Open Chat" onclick={toggleWindow} class="launcher"></lightning-button-icon>
+    </template>
+    <template if:true={open}>
+        <c-chat-window onclose={toggleWindow}></c-chat-window>
+    </template>
+</template>

--- a/force-app/main/default/lwc/chatLauncher/chatLauncher.js
+++ b/force-app/main/default/lwc/chatLauncher/chatLauncher.js
@@ -1,0 +1,9 @@
+import { LightningElement, track } from 'lwc';
+
+export default class ChatLauncher extends LightningElement {
+    @track open = false;
+
+    toggleWindow() {
+        this.open = !this.open;
+    }
+}

--- a/force-app/main/default/lwc/chatLauncher/chatLauncher.js-meta.xml
+++ b/force-app/main/default/lwc/chatLauncher/chatLauncher.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="chatLauncher">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/chatMessage/chatMessage.css
+++ b/force-app/main/default/lwc/chatMessage/chatMessage.css
@@ -1,0 +1,6 @@
+.user {
+    text-align: right;
+}
+.bot {
+    text-align: left;
+}

--- a/force-app/main/default/lwc/chatMessage/chatMessage.html
+++ b/force-app/main/default/lwc/chatMessage/chatMessage.html
@@ -1,0 +1,5 @@
+<template>
+    <div class={computedClass}>
+        <span>{message.text}</span>
+    </div>
+</template>

--- a/force-app/main/default/lwc/chatMessage/chatMessage.js
+++ b/force-app/main/default/lwc/chatMessage/chatMessage.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ChatMessage extends LightningElement {
+    @api message;
+
+    get computedClass() {
+        return this.message.author === 'user' ? 'user' : 'bot';
+    }
+}

--- a/force-app/main/default/lwc/chatMessage/chatMessage.js-meta.xml
+++ b/force-app/main/default/lwc/chatMessage/chatMessage.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="chatMessage">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/chatService/chatService.js
+++ b/force-app/main/default/lwc/chatService/chatService.js
@@ -1,0 +1,23 @@
+let history = [];
+const API_URL = '/chat';
+
+export async function sendMessage(query) {
+    const body = { query, history };
+    const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    const data = await response.json();
+    history.push({ role: 'user', content: query });
+    history.push({ role: 'assistant', content: data.answer });
+    return data;
+}
+
+export function getHistory() {
+    return [...history];
+}
+
+export function clearHistory() {
+    history = [];
+}

--- a/force-app/main/default/lwc/chatWindow/chatWindow.css
+++ b/force-app/main/default/lwc/chatWindow/chatWindow.css
@@ -1,0 +1,34 @@
+.window {
+    position: fixed;
+    bottom: 4rem;
+    right: 1rem;
+    width: 300px;
+    height: 400px;
+    background: white;
+    border: 1px solid #ccc;
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+}
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem;
+    background: #f3f3f3;
+    border-bottom: 1px solid #ccc;
+}
+.messages {
+    flex: 1;
+    overflow: auto;
+    padding: 0.5rem;
+}
+.input {
+    display: flex;
+    padding: 0.5rem;
+}
+.loading {
+    text-align: center;
+    font-style: italic;
+    padding: 0.5rem;
+}

--- a/force-app/main/default/lwc/chatWindow/chatWindow.html
+++ b/force-app/main/default/lwc/chatWindow/chatWindow.html
@@ -1,0 +1,20 @@
+<template>
+    <section class="window">
+        <div class="header">
+            <span>Chatbot</span>
+            <lightning-button-icon icon-name="utility:close" alternative-text="Close" onclick={close}></lightning-button-icon>
+        </div>
+        <div class="messages">
+            <template for:each={messages} for:item="msg">
+                <c-chat-message key={msg.id} message={msg}></c-chat-message>
+            </template>
+            <template if:true={loading}>
+                <div class="loading">Loading...</div>
+            </template>
+        </div>
+        <div class="input">
+            <lightning-input value={input} onchange={handleChange} onkeypress={handleKeyPress}></lightning-input>
+            <lightning-button label="Send" onclick={send}></lightning-button>
+        </div>
+    </section>
+</template>

--- a/force-app/main/default/lwc/chatWindow/chatWindow.js
+++ b/force-app/main/default/lwc/chatWindow/chatWindow.js
@@ -1,0 +1,50 @@
+import { LightningElement, track } from 'lwc';
+import { sendMessage } from 'c/chatService';
+
+export default class ChatWindow extends LightningElement {
+    @track messages = [];
+    @track input = '';
+    @track loading = false;
+
+    handleChange(event) {
+        this.input = event.target.value;
+    }
+
+    handleKeyPress(event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.send();
+        }
+    }
+
+    async send() {
+        const text = this.input.trim();
+        if (!text) {
+            return;
+        }
+        this.messages = [
+            ...this.messages,
+            { id: Date.now(), author: 'user', text }
+        ];
+        this.input = '';
+        this.loading = true;
+        try {
+            const data = await sendMessage(text);
+            this.messages = [
+                ...this.messages,
+                { id: Date.now() + 1, author: 'bot', text: data.answer }
+            ];
+        } catch (e) {
+            this.messages = [
+                ...this.messages,
+                { id: Date.now() + 1, author: 'bot', text: 'Error contacting server' }
+            ];
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    close() {
+        this.dispatchEvent(new CustomEvent('close'));
+    }
+}

--- a/force-app/main/default/lwc/chatWindow/chatWindow.js-meta.xml
+++ b/force-app/main/default/lwc/chatWindow/chatWindow.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="chatWindow">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add `chatLauncher`, `chatWindow`, and `chatMessage` Lightning Web Components
- create shared `chatService.js` for calling the `/chat` endpoint
- implement a simple loading indicator while awaiting responses

## Testing
- `npm test` *(fails: `sfdx-lwc-jest` not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68663aabd1988327af63bd29166ebf54